### PR TITLE
Add read and write functions for level in local db

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/swenggolf/LocalDatabaseTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/swenggolf/LocalDatabaseTest.java
@@ -26,12 +26,21 @@ public class LocalDatabaseTest {
 
 
     @Test
-    public void writeAndReadTest() {
+    public void writeAndReadCategoriesTest() {
         LocalDatabase localDb = new LocalDatabase(activityRule.getActivity(), null, 1);
         List<Category> allCategories = Arrays.asList(Category.values());
         localDb.writeCategories(allCategories);
         List<Category> readCategories = localDb.readCategories();
         assertEquals(allCategories, readCategories);
+    }
+
+    @Test
+    public void writeAndReadLevelTest() {
+        LocalDatabase localDb = new LocalDatabase(activityRule.getActivity(), null, 1);
+        int level = 5;
+        localDb.writeLevel(level);
+        int readLevel = localDb.readLevel();
+        assertEquals(level, readLevel);
     }
 
     @Test

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/database/LocalDatabase.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/database/LocalDatabase.java
@@ -16,8 +16,10 @@ import ch.epfl.sweng.swenggolf.offer.Category;
 public class LocalDatabase extends SQLiteOpenHelper {
 
     private static final String COLUMN_CATEGORIES = "categories";
+    private static final String COLUMN_REPUTATION = "reputation";
     private static final String DEFAULT_DATABASE_NAME = "local.db";
-    private static final String TABLE_NAME = "filters";
+    private static final String TABLE_NAME_FILTERS = "filters";
+    private static final String TABLE_NAME_LEVEL = "level";
     private static final String COLUMN_ID = "_id";
 
     /**
@@ -44,14 +46,18 @@ public class LocalDatabase extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase db) {
-        String sqlQueryForCreation = "CREATE TABLE " + TABLE_NAME + "(" + COLUMN_ID
+        String sqlQueryForCreation = "CREATE TABLE " + TABLE_NAME_FILTERS + "(" + COLUMN_ID
                 + " INTEGER PRIMARY KEY, " + COLUMN_CATEGORIES + " TEXT NOT NULL);";
+        db.execSQL(sqlQueryForCreation);
+        sqlQueryForCreation = "CREATE TABLE " + TABLE_NAME_LEVEL + "(" + COLUMN_ID
+                + " INTEGER PRIMARY KEY, " + COLUMN_REPUTATION + " INTEGER);";
         db.execSQL(sqlQueryForCreation);
     }
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        db.execSQL("DROP TABLE IF EXISTS " + TABLE_NAME);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_NAME_FILTERS);
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_NAME_LEVEL);
         onCreate(db);
     }
 
@@ -66,7 +72,20 @@ public class LocalDatabase extends SQLiteOpenHelper {
         ContentValues values = new ContentValues();
         values.put(COLUMN_CATEGORIES, Category.categoriesToSingleString(categories));
 
-        database.insert(TABLE_NAME, null, values);
+        database.insert(TABLE_NAME_FILTERS, null, values);
+        database.close();
+    }
+
+    /**
+     * Writes the current reputation level into the local SQLite database.
+     *
+     * @param level The current level
+     */
+    public void writeLevel(int level){
+        SQLiteDatabase database = this.getWritableDatabase();
+        ContentValues values = new ContentValues();
+        values.put(COLUMN_REPUTATION, level);
+        database.insert(TABLE_NAME_LEVEL, null, values);
         database.close();
     }
 
@@ -78,7 +97,7 @@ public class LocalDatabase extends SQLiteOpenHelper {
     public List<Category> readCategories() {
         SQLiteDatabase db = this.getWritableDatabase();
 
-        String query = "Select * FROM " + TABLE_NAME + " ORDER BY " + COLUMN_ID + " DESC LIMIT 1";
+        String query = "Select * FROM " + TABLE_NAME_FILTERS + " ORDER BY " + COLUMN_ID + " DESC LIMIT 1";
         Cursor cursor = db.rawQuery(query, null);
 
         String categories = "";
@@ -90,5 +109,26 @@ public class LocalDatabase extends SQLiteOpenHelper {
         db.close();
 
         return Category.singleStringToCategories(categories);
+    }
+
+    /**
+     * Reads the saved reputation level and returns it
+     *
+     * @return the level saved in the database
+     */
+    public int readLevel() {
+        SQLiteDatabase db = this.getWritableDatabase();
+
+        String query = "Select * FROM " + TABLE_NAME_LEVEL + " ORDER BY " + COLUMN_ID + " DESC LIMIT 1";
+        Cursor cursor = db.rawQuery(query, null);
+
+        int level = 0;
+
+        if (cursor.moveToFirst()) {
+            level = cursor.getInt(1);
+            cursor.close();
+        }
+        db.close();
+        return level;
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/database/LocalDatabase.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/database/LocalDatabase.java
@@ -97,7 +97,8 @@ public class LocalDatabase extends SQLiteOpenHelper {
     public List<Category> readCategories() {
         SQLiteDatabase db = this.getWritableDatabase();
 
-        String query = "Select * FROM " + TABLE_NAME_FILTERS + " ORDER BY " + COLUMN_ID + " DESC LIMIT 1";
+        String query = "Select * FROM " + TABLE_NAME_FILTERS + " ORDER BY "
+                + COLUMN_ID + " DESC LIMIT 1";
         Cursor cursor = db.rawQuery(query, null);
 
         String categories = "";
@@ -112,14 +113,15 @@ public class LocalDatabase extends SQLiteOpenHelper {
     }
 
     /**
-     * Reads the saved reputation level and returns it
+     * Reads the saved reputation level and returns it.
      *
      * @return the level saved in the database
      */
     public int readLevel() {
         SQLiteDatabase db = this.getWritableDatabase();
 
-        String query = "Select * FROM " + TABLE_NAME_LEVEL + " ORDER BY " + COLUMN_ID + " DESC LIMIT 1";
+        String query = "Select * FROM " + TABLE_NAME_LEVEL + " ORDER BY "
+                + COLUMN_ID + " DESC LIMIT 1";
         Cursor cursor = db.rawQuery(query, null);
 
         int level = 0;


### PR DESCRIPTION
Adds a new table in the local database for the storage of the reputation level.

If the app is not cleanly uninstalled and reinstalled, you might have to do the following procedure:
In Android studio go to `View` -> `Tool Windows` -> `Device File Explorer` (open your emulator or Phone)
Navigate to `data/data/ch.epfl.sweng.swenggolf/databases` and delete the `local.db` database and its log file (and the others as well if you want)
