### PR TITLE
Fix menu in leaderboard and infinite filling

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sweng/swenggolf/LeaderboardTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/swenggolf/LeaderboardTest.java
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith;
 import ch.epfl.sweng.swenggolf.database.Database;
 import ch.epfl.sweng.swenggolf.database.DatabaseUser;
 import ch.epfl.sweng.swenggolf.database.FakeDatabase;
+import ch.epfl.sweng.swenggolf.leaderboard.Leaderboard;
+import ch.epfl.sweng.swenggolf.leaderboard.LeaderboardAdapter;
 import ch.epfl.sweng.swenggolf.main.MainMenuActivity;
 import ch.epfl.sweng.swenggolf.profile.User;
 

--- a/app/src/androidTest/java/ch/epfl/sweng/swenggolf/MainMenuActivityInstrumentedTestIntents.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/swenggolf/MainMenuActivityInstrumentedTestIntents.java
@@ -17,6 +17,7 @@ import java.util.List;
 import ch.epfl.sweng.swenggolf.database.Database;
 import ch.epfl.sweng.swenggolf.database.FakeDatabase;
 import ch.epfl.sweng.swenggolf.database.FilledFakeDatabase;
+import ch.epfl.sweng.swenggolf.leaderboard.Leaderboard;
 import ch.epfl.sweng.swenggolf.main.MainMenuActivity;
 import ch.epfl.sweng.swenggolf.offer.ListOfferActivity;
 import ch.epfl.sweng.swenggolf.offer.ListOwnOfferActivity;

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/Leaderboard.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/Leaderboard.java
@@ -8,6 +8,9 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -38,12 +41,29 @@ public class Leaderboard extends FragmentConverter {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstance) {
+        userList.clear();
+
         setToolbar(R.drawable.ic_menu_black_24dp, R.string.leaderboard);
+        super.onCreate(savedInstance);
         View inflated = inflater.inflate(R.layout.activity_leaderboard, container, false);
         errorMessage = inflated.findViewById(R.id.error_message);
         noUser = inflated.findViewById(R.id.no_user_to_show);
         setRecyclerView(inflated);
         return inflated;
+    }
+
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home: {
+                openDrawer();
+                return true;
+            }
+            default: {
+                return super.onOptionsItemSelected(item);
+            }
+        }
     }
 
 

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/Leaderboard.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/Leaderboard.java
@@ -8,8 +8,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -44,7 +42,6 @@ public class Leaderboard extends FragmentConverter {
         userList.clear();
 
         setToolbar(R.drawable.ic_menu_black_24dp, R.string.leaderboard);
-        super.onCreate(savedInstance);
         View inflated = inflater.inflate(R.layout.activity_leaderboard, container, false);
         errorMessage = inflated.findViewById(R.id.error_message);
         noUser = inflated.findViewById(R.id.no_user_to_show);

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/Leaderboard.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/Leaderboard.java
@@ -55,15 +55,9 @@ public class Leaderboard extends FragmentConverter {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home: {
-                openDrawer();
-                return true;
-            }
-            default: {
-                return super.onOptionsItemSelected(item);
-            }
-        }
+        super.onOptionsItemSelected(item);
+        openDrawer();
+        return true;
     }
 
 

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/leaderboard/Leaderboard.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/leaderboard/Leaderboard.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.swenggolf;
+package ch.epfl.sweng.swenggolf.leaderboard;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -16,6 +16,7 @@ import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.List;
 
+import ch.epfl.sweng.swenggolf.R;
 import ch.epfl.sweng.swenggolf.database.AttributeOrdering;
 import ch.epfl.sweng.swenggolf.database.Database;
 import ch.epfl.sweng.swenggolf.database.DatabaseUser;

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/leaderboard/LeaderboardAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/leaderboard/LeaderboardAdapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.swenggolf;
+package ch.epfl.sweng.swenggolf.leaderboard;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
@@ -13,6 +13,7 @@ import com.squareup.picasso.Picasso;
 
 import java.util.List;
 
+import ch.epfl.sweng.swenggolf.R;
 import ch.epfl.sweng.swenggolf.profile.Badge;
 import ch.epfl.sweng.swenggolf.profile.User;
 import ch.epfl.sweng.swenggolf.tools.FragmentConverter;

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/main/MainMenuActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/main/MainMenuActivity.java
@@ -15,7 +15,7 @@ import android.widget.TextView;
 import com.squareup.picasso.Picasso;
 
 import ch.epfl.sweng.swenggolf.Config;
-import ch.epfl.sweng.swenggolf.Leaderboard;
+import ch.epfl.sweng.swenggolf.leaderboard.Leaderboard;
 import ch.epfl.sweng.swenggolf.R;
 import ch.epfl.sweng.swenggolf.notification.NotificationsActivity;
 import ch.epfl.sweng.swenggolf.offer.ListOfferActivity;


### PR DESCRIPTION
The main menu wasn't accessible from the leaderboard before. Also, the leaderboard wasn't cleaned before reloading the data, resulting in an infinite filling of the list.

_This solves issue #149._