### PR TITLE
Add onResume function call

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/swenggolf/main/MainMenuActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/main/MainMenuActivity.java
@@ -17,6 +17,7 @@ import com.squareup.picasso.Picasso;
 import ch.epfl.sweng.swenggolf.Config;
 import ch.epfl.sweng.swenggolf.R;
 import ch.epfl.sweng.swenggolf.leaderboard.Leaderboard;
+import ch.epfl.sweng.swenggolf.network.Network;
 import ch.epfl.sweng.swenggolf.network.NetworkReceiver;
 import ch.epfl.sweng.swenggolf.notification.NotificationsActivity;
 import ch.epfl.sweng.swenggolf.offer.list.ListOfferActivity;
@@ -57,6 +58,12 @@ public class MainMenuActivity extends AppCompatActivity {
         if (savedInstances == null) {
             launchFragment();
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        Network.updateStatus(this);
     }
 
     private void setToolBar() {


### PR DESCRIPTION
This hotfix addresses the issue https://github.com/SwengGolfTeam/Sweng_Golf/issues/203 that was brought up this morning at the scrum meeting.

We are now updating the status of the internet connection of the device when resuming the `mainActivity` so if there was a change of the connectivity while the app was not in the foreground, it will be detected when returning on the app and the banner is displayed/hidden accordingly.