### PR TITLE
Delete closed offers

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/swenggolf/database/Database.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/database/Database.java
@@ -1,5 +1,6 @@
 package ch.epfl.sweng.swenggolf.database;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
@@ -221,4 +222,6 @@ public abstract class Database {
         }
         return list;
     }
+
+    public abstract void deleteOffer(@NonNull Offer offer, @NonNull CompletionListener listener);
 }

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/database/FakeDatabase.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/database/FakeDatabase.java
@@ -1,5 +1,6 @@
 package ch.epfl.sweng.swenggolf.database;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -183,6 +184,16 @@ public class FakeDatabase extends Database {
                            List<Category> categories) {
         FakeDatabaseListHandler.readOffers(working, this.<Offer>getList(OFFERS_PATH),
                 listener, categories);
+    }
+
+    @Override
+    public void deleteOffer(@NonNull Offer offer, @NonNull CompletionListener listener) {
+        if (working) {
+            database.remove(Database.OFFERS_PATH + "/" + offer.getUuid());
+            listener.onComplete(DbError.NONE);
+        } else {
+            listener.onComplete(DbError.UNKNOWN_ERROR);
+        }
     }
 
 

--- a/app/src/main/java/ch/epfl/sweng/swenggolf/database/FireDatabase.java
+++ b/app/src/main/java/ch/epfl/sweng/swenggolf/database/FireDatabase.java
@@ -1,8 +1,12 @@
 package ch.epfl.sweng.swenggolf.database;
 
+import android.app.Activity;
+import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.util.Pair;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -17,9 +21,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import ch.epfl.sweng.swenggolf.R;
 import ch.epfl.sweng.swenggolf.network.Network;
 import ch.epfl.sweng.swenggolf.offer.Category;
 import ch.epfl.sweng.swenggolf.offer.Offer;
+import ch.epfl.sweng.swenggolf.statistics.OfferStats;
+import ch.epfl.sweng.swenggolf.storage.Storage;
 
 import static ch.epfl.sweng.swenggolf.database.DbError.DISCONNECTED;
 import static ch.epfl.sweng.swenggolf.database.DbError.NONE;
@@ -208,6 +215,26 @@ public final class FireDatabase extends Database {
             Query query = ref.orderByChild("tag").equalTo(categories.get(i).toString());
             readListQuery(listener, query, Offer.class, false);
         }
+    }
+
+    @Override
+    public void deleteOffer(@NonNull final Offer offer, @NonNull CompletionListener listener) {
+        if (!offer.getLinkPicture().isEmpty()) {
+            Storage storage = Storage.getInstance();
+            storage.remove(offer.getLinkPicture());
+        }
+        Database database = Database.getInstance();
+
+        CompletionListener emptyListener = new CompletionListener() {
+            @Override
+            public void onComplete(DbError error) {
+                // Does nothing;
+            }
+        };
+
+        database.remove(Database.OFFERS_PATH, offer.getUuid(), listener);
+        database.remove(Database.ANSWERS_PATH, offer.getUuid(), emptyListener);
+        database.remove(Database.MESSAGES_PATH, offer.getUuid(), emptyListener);
     }
 
     private <T> void readListQuery(

--- a/app/src/main/res/menu/menu_closed_offer.xml
+++ b/app/src/main/res/menu/menu_closed_offer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/button_delete_closed_offer"
+        android:icon="@android:drawable/ic_menu_delete"
+        android:title="@string/edit_profile_activity_name"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,5 +82,6 @@
     <string name="closed">closed</string>
     <string name="open">open</string>
     <string name="old_offer_found">Old offer found</string>
-    <string name="restore_offer_message">You already started creating an offer. Do you want to continue to edit it ?</string>
+    <string name="restore_offer_message">You already started creating an offer. Do you want to continue to edit it?</string>
+    <string name="offer_deleted_error">Could not delete offer</string>
 </resources>


### PR DESCRIPTION
_This solves issue #186._

A user can now delete their own closed offers. This has no impact on statistics and points, since we assume that there is no cheating involved (could be argued of course).